### PR TITLE
fix compile error with JDK > 1.6

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -1,6 +1,8 @@
 grails.project.class.dir = "target/classes"
 grails.project.test.class.dir = "target/test-classes"
 grails.project.test.reports.dir = "target/test-reports"
+grails.project.target.level = 1.6
+grails.project.source.level = 1.6
 grails.project.dependency.resolution = {
 	inherits( "global" )
 	log "warn"


### PR DESCRIPTION
This request fixes the error below when compiling the plugin with JDK 1.7:

| Error Compilation error: startup failed:
Invalid commandline usage for javac.
javac: target release 1.6 conflicts with default source release 1.7
