### PR TITLE
Update for Groovy 2.4

### DIFF
--- a/RemoteControlGrailsPlugin.groovy
+++ b/RemoteControlGrailsPlugin.groovy
@@ -16,7 +16,7 @@
 
 class RemoteControlGrailsPlugin {
 
-	def version = "1.5"
+	def version = "2.0"
 	def grailsVersion = "2.0.0 > *"
 	def dependsOn = [:]
 	def pluginExcludes = ["grails-app/**/*", "scripts/**/*"]

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -11,9 +11,11 @@ grails.project.dependency.resolution = {
 		grailsHome()
 		mavenLocal()
 		mavenCentral()
+		mavenRepo "http://dl.bintray.com/alkemist/maven"
 	}
 	dependencies {
-		compile "org.codehaus.groovy.modules.remote:remote-transport-http:0.5", {
+		compile "io.remotecontrol:remote-core:0.7"
+		compile "io.remotecontrol:remote-transport-http:0.7", {
 			excludes "servlet-api"
 		}
 	}
@@ -21,7 +23,7 @@ grails.project.dependency.resolution = {
 		compile (
 			":tomcat:$grailsVersion",
 			":hibernate:$grailsVersion",
-			":spock:0.6",
+			":spock:0.6"
 		) {
 			export = false
 		}

--- a/src/groovy/grails/plugin/remotecontrol/RemoteControl.groovy
+++ b/src/groovy/grails/plugin/remotecontrol/RemoteControl.groovy
@@ -16,12 +16,12 @@
 package grails.plugin.remotecontrol
 
 import grails.util.BuildSettingsHolder
-import groovyx.remote.transport.http.HttpTransport
+import io.remotecontrol.transport.http.HttpTransport
 
 /**
  * Adds grails specific convenient no arg constructor
  */
-class RemoteControl extends groovyx.remote.client.RemoteControl {
+class RemoteControl extends io.remotecontrol.groovy.client.RemoteControl {
 
 	static public final RECEIVER_PATH = "grails-remote-control"
 	 

--- a/src/groovy/grails/plugin/remotecontrol/RemoteControlServlet.groovy
+++ b/src/groovy/grails/plugin/remotecontrol/RemoteControlServlet.groovy
@@ -17,11 +17,12 @@ package grails.plugin.remotecontrol
 
 import javax.servlet.*
 import javax.servlet.http.*
-import groovyx.remote.server.Receiver
+import io.remotecontrol.server.Receiver
+import io.remotecontrol.groovy.server.ClosureReceiver
 import grails.util.Holders
 import grails.util.Environment
 
-class RemoteControlServlet extends groovyx.remote.transport.http.RemoteControlServlet {
+class RemoteControlServlet extends io.remotecontrol.transport.http.RemoteControlServlet {
 	
 	void doExecute(InputStream input, OutputStream output) {
 		def persistenceInterceptor = grailsApplication?.mainContext?.persistenceInterceptor
@@ -48,7 +49,7 @@ class RemoteControlServlet extends groovyx.remote.transport.http.RemoteControlSe
 	}
 	
 	protected Receiver createReceiver() {
-		new Receiver(grailsApplication.classLoader, [app: grailsApplication, ctx: grailsApplication.mainContext])
+		new ClosureReceiver(grailsApplication.classLoader, [app: grailsApplication, ctx: grailsApplication.mainContext])
 	}
 	
 	boolean isEnabled() {

--- a/test/functional/SmokeTests.groovy
+++ b/test/functional/SmokeTests.groovy
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 import grails.plugin.remotecontrol.RemoteControl
-import groovyx.remote.client.RemoteException
-import groovyx.remote.client.UnserializableReturnException
+import io.remotecontrol.client.RemoteException
+import io.remotecontrol.client.UnserializableReturnException
+import io.remotecontrol.UnserializableCommandException
 
 /**
  * This test case shows how to use the remote control and some of it's limitations
@@ -134,7 +135,7 @@ class SmokeTests extends GroovyTestCase {
 	 */
 	void testAccessingNonSerializableLexicalScope() {
 		def a = System.out
-		shouldFail(NotSerializableException) {
+		shouldFail(UnserializableCommandException) {
 			remote.exec { a }
 		}
 	}
@@ -178,7 +179,7 @@ class SmokeTests extends GroovyTestCase {
 	 * Like everything else, currying args must be serialisable
 	 */
 	void testCurryingArgsMustBeSerializable() {
-		shouldFail(NotSerializableException) {
+		shouldFail(UnserializableCommandException) {
 			remote.exec({ it }.curry(System.out))
 		}
 	}


### PR DESCRIPTION
Use remote control 0.7 to support Groovy 2.4 closure classes. Fixes #23